### PR TITLE
Rename directmessage to dm

### DIFF
--- a/directmessage/directmessage.py
+++ b/directmessage/directmessage.py
@@ -34,9 +34,13 @@ class DirectMessage(commands.Cog):
 
     @commands.is_owner()
     @commands.command(name="directmessage", aliases=["sdm"])
-    async def _direct_message(self, ctx: commands.Context, user: discord.User, *, message):
+    async def _direct_message(self, ctx: commands.Context, user: discord.User, *, title, message):
         """Sends a DM to a user (sends raw text directly)."""
+        embed =  discord.Embed(
+            title=title,
+            description=message
+        )
         try:
-            await user.send(message)
+            await user.send(embed=embed)
         except discord.Forbidden:
             await ctx.author.send(f"User does not have DMs enabled.")


### PR DESCRIPTION
This PR renames the ``[p]directmessage`` command to ``[p]dm`` (with direct message now as an lias) and with this is, it also adds command replacement things so the cog can load.